### PR TITLE
更新依赖列表中的sklearn为scikit-learn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ torch = "1.12.1"
 scipy = "^1.8"
 optuna = "*"
 numpy = "*"
-sklearn = "*"
+scikit-learn = "*"
 requests = "*"
 matplotlib = "*"
 


### PR DESCRIPTION
sklearn是一个错误的包名，版本号只有0.0，是不应该被安装的。详见 https://pypi.org/project/sklearn/  正确的包名应为scikit-learn。