### PR TITLE
优化对torch版本的依赖声明为>=1.12.1且<2.0

### DIFF
--- a/docs/source/start/install.rst
+++ b/docs/source/start/install.rst
@@ -7,7 +7,7 @@ Installation
     - Proof: Xinwei Zhang
 
 - Python >= 3.8
-- Pytorch >=1.11
+- Pytorch >= 1.12
 
 Current, the stable version of **DHG** is 0.9.2. You can install it with ``pip`` as follows:
 

--- a/docs/source/zh/start/install.rst
+++ b/docs/source/zh/start/install.rst
@@ -8,7 +8,7 @@
     - 校对： `丰一帆 <https://fengyifan.site/>`_ 、张欣炜
 
 - Python >= 3.8
-- Pytorch >=1.11
+- Pytorch >= 1.12
 
 
 目前， **DHG** 的最新稳定版本 **0.9.2** 已经发布，可以使用 ``pip`` 指令直接安装：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-torch = "1.12.1"
+torch = ">= 1.12.1, < 2.0"
 scipy = "^1.8"
 optuna = "*"
 numpy = "*"


### PR DESCRIPTION
否则，现在的写法是要求用户的pytorch版本严格等于1.12.1，即使用户已经安装了更新的版本也是不行的。我认为应当允许用户使用任何Pytorch 1.X（只要大于某个特定版本，因为我们的程序可能会使用某些较新的Pytorch特性）。
根据语义化版本规则，相同的大版本号一般意味着没有API Breaking Changes，因此这样做应当不会产生问题，同时也给了用户更大的自由。 
PS：版本声明字符串的语法参考https://python-poetry.org/docs/dependency-specification/#multiple-requirements