### PR TITLE
添加 Link prediction metric

### DIFF
--- a/dhg/metrics/__init__.py
+++ b/dhg/metrics/__init__.py
@@ -5,6 +5,7 @@ from .classification import (
 )
 from .retrieval import available_retrieval_metrics, RetrievalEvaluator
 from .recommender import available_recommender_metrics, UserItemRecommenderEvaluator
+from .link_prediction import available_link_prediction_metrics, LinkPredictionEvaluator
 from .graphs import GraphVertexClassificationEvaluator
 from .hypergraphs import HypergraphVertexClassificationEvaluator
 
@@ -20,7 +21,7 @@ def build_evaluator(
     r"""Return the metric evaluator for the given task.
     
     Args:
-        ``task`` (``str``): The type of the task. The supported types include: ``graph_vertex_classification``, ``hypergraph_vertex_classification``, and ``user_item_recommender``.
+        ``task`` (``str``): The type of the task. The supported types include: ``graph_vertex_classification``, ``hypergraph_vertex_classification``, ``user_item_recommender`` and ``link_prediction``.
         ``metric_configs`` (``List[Union[str, Dict[str, dict]]]``): The list of metric names.
         ``validate_index`` (``int``): The specified metric index used for validation. Defaults to ``0``.
     """
@@ -30,6 +31,8 @@ def build_evaluator(
         return HypergraphVertexClassificationEvaluator(metric_configs, validate_index)
     elif task == "user_item_recommender":
         return UserItemRecommenderEvaluator(metric_configs, validate_index)
+    elif task == "link_prediction":
+        return LinkPredictionEvaluator(metric_configs, validate_index)
     else:
         raise ValueError(
             f"{task} is not supported yet. Please email '{AUTHOR_EMAIL}' to add it."
@@ -42,9 +45,11 @@ __all__ = [
     "available_classification_metrics",
     "available_retrieval_metrics",
     "available_recommender_metrics",
+    "available_link_prediction_metrics"
     "VertexClassificationEvaluator",
     "GraphVertexClassificationEvaluator",
     "HypergraphVertexClassificationEvaluator",
     "UserItemRecommenderEvaluator",
     "RetrievalEvaluator",
+    "LinkPredictionEvaluator",
 ]

--- a/dhg/metrics/__init__.py
+++ b/dhg/metrics/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
     "available_classification_metrics",
     "available_retrieval_metrics",
     "available_recommender_metrics",
-    "available_link_prediction_metrics"
+    "available_link_prediction_metrics",
     "VertexClassificationEvaluator",
     "GraphVertexClassificationEvaluator",
     "HypergraphVertexClassificationEvaluator",

--- a/dhg/metrics/base.py
+++ b/dhg/metrics/base.py
@@ -29,6 +29,10 @@ def format_metric_configs(task: str, metric_configs: List[Union[str, Dict[str, d
         import dhg.metrics.recommender as module
 
         available_metrics = module.available_recommender_metrics()
+    elif task == "link_prediction":
+        import dhg.metrics.link_prediction as module
+
+        available_metrics = module.available_link_prediction_metrics()
     else:
         raise ValueError(f"Task {task} is not supported yet. Please email '{AUTHOR_EMAIL}' to add it.")
     metric_list = []
@@ -73,7 +77,7 @@ class BaseEvaluator:
     r"""The base class for task-specified metric evaluators.
     
     Args:
-        ``task`` (``str``): The type of the task. The supported types include: ``classification``, ``retrieval`` and ``recommender``.
+        ``task`` (``str``): The type of the task. The supported types include: ``classification``, ``retrieval``, ``user_item_recommender`` and ``link_prediction``.
         ``metric_configs`` (``List[Union[str, Dict[str, dict]]]``): The metric configurations. The key is the metric name and the value is the metric parameters.
         ``validate_index`` (``int``): The specified metric index used for validation. Defaults to ``0``.
     """

--- a/dhg/metrics/link_prediction.py
+++ b/dhg/metrics/link_prediction.py
@@ -1,0 +1,179 @@
+from typing import Union, List, Dict
+
+import torch
+import sklearn.metrics as sm
+
+from .base import BaseEvaluator
+
+__all__ = [
+    "available_link_prediction_metrics",
+    "accuracy",
+    "f1_score",
+    "confusion_matrix",
+    "auc"
+    "LinkPredictionEvaluator",
+]
+
+
+def available_link_prediction_metrics():
+    r"""Return available metrics for the link prediction task. 
+    
+    The available metrics are: ``accuracy``, ``f1_score``, ``confusion_matrix``, ``auc``.
+    """
+    return ("accuracy", "f1_score", "confusion_matrix", "auc")
+
+
+def _format_inputs(y_true: torch.LongTensor, y_pred: torch.Tensor):
+    r"""Format the inputs.
+
+    Args:
+        ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+        ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+    """
+    assert y_true.dim() == 1, "y_true must be 1D torch.LongTensor."
+    assert y_pred.dim() in (1, 2), "y_pred must be 1D or 2D torch.Tensor."
+    y_true = y_true.cpu().detach()
+    if y_pred.dim() == 2:
+        y_pred = y_pred.argmax(dim=1)
+    y_pred = y_pred.cpu().detach()
+    assert y_true.shape == y_pred.shape, "y_true and y_pred must have the same length."
+    return (y_true, y_pred)
+
+
+def accuracy(y_true: torch.LongTensor, y_pred: torch.Tensor):
+    r"""Calculate the accuracy score for the link prediction task.
+
+    .. math::
+        \text{Accuracy} = \frac{1}{N} \sum_{i=1}^{N} \mathcal{I}(y_i, \hat{y}_i),
+    
+    where :math:`\mathcal{I}(\cdot, \cdot)` is the indicator function, which is 1 if the two inputs are equal, and 0 otherwise.
+    :math:`y_i` and :math:`\hat{y}_i` are the ground truth and predicted labels for the i-th sample.
+
+    Args:
+        ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+        ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+
+    Examples:
+        >>> import torch
+        >>> import dhg.metrics as dm
+        >>> y_true = torch.tensor([3, 2, 4])
+        >>> y_pred = torch.tensor([
+                [0.2, 0.3, 0.5, 0.4, 0.3],
+                [0.8, 0.2, 0.3, 0.5, 0.4],
+                [0.2, 0.4, 0.5, 0.2, 0.8],
+            ])
+        >>> dm.link_prediction.accuracy(y_true, y_pred)
+        0.3333333432674408
+    """
+    y_true, y_pred = _format_inputs(y_true, y_pred)
+    return (y_true == y_pred).float().mean().item()
+
+
+def f1_score(y_true: torch.LongTensor, y_pred: torch.Tensor, average: str = "macro"):
+    r"""Calculate the F1 score for the link prediction task.
+
+    Args:
+        ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+        ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+        ``average`` (``str``): The average method. Must be one of "macro", "micro", "weighted".
+
+    Examples:
+        >>> import torch
+        >>> import dhg.metrics as dm
+        >>> y_true = torch.tensor([3, 2, 4, 0])
+        >>> y_pred = torch.tensor([
+                [0.2, 0.3, 0.5, 0.4, 0.3],
+                [0.8, 0.2, 0.3, 0.5, 0.4],
+                [0.2, 0.4, 0.5, 0.2, 0.8],
+                [0.8, 0.4, 0.5, 0.2, 0.8]
+            ])
+        >>> dm.link_prediction.f1_score(y_true, y_pred, "macro")
+        0.41666666666666663
+        >>> dm.link_prediction.f1_score(y_true, y_pred, "micro")
+        0.5
+        >>> dm.link_prediction.f1_score(y_true, y_pred, "weighted")
+        0.41666666666666663
+    """
+    y_true, y_pred = _format_inputs(y_true, y_pred)
+    return sm.f1_score(y_true, y_pred, average=average)
+
+
+def confusion_matrix(y_true: torch.LongTensor, y_pred: torch.Tensor):
+    r"""Calculate the confusion matrix for the link prediction task.
+
+    Args:
+        ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+        ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, )`.
+
+    Examples:
+        >>> import torch
+        >>> import dhg.metrics as dm
+        >>> y_true = torch.tensor([3, 2, 4, 0])
+        >>> y_pred = torch.tensor([
+                [0.2, 0.3, 0.5, 0.4, 0.3],
+                [0.8, 0.2, 0.3, 0.5, 0.4],
+                [0.2, 0.4, 0.5, 0.2, 0.8],
+                [0.8, 0.4, 0.5, 0.2, 0.8]
+            ])
+        >>> dm.link_prediction.confusion_matrix(y_true, y_pred)
+        array([[1, 0, 0, 0],
+               [1, 0, 0, 0],
+               [0, 1, 0, 0],
+               [0, 0, 0, 1]])
+    """
+    y_true, y_pred = _format_inputs(y_true, y_pred)
+    return sm.confusion_matrix(y_true, y_pred)
+
+def auc(y_true: torch.LongTensor, y_pred: torch.Tensor):
+    r"""Calculate the auc for the link prediction task.
+
+    Args:
+        ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+        ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+
+    Examples:
+        >>> import torch
+        >>> import dhg.metrics as dm
+        >>> y_pred = torch.tensor([0.2, 0.3, 0.5, 0.4, 0.3])
+        >>> y_true = torch.tensor([1, 0, 1, 1, 0])
+        >>> y_pred = torch.tensor([0.2, 0.1, 0.5, 0.8, 0.3])
+        >>> dm.link_prediction.auc(y_true, y_pred)
+        0.8333333333333333
+    """
+    y_true, y_pred = _format_inputs(y_true, y_pred)
+    return sm.roc_auc_score(y_true, y_pred)
+
+
+# Link Prediction Evaluator
+class LinkPredictionEvaluator(BaseEvaluator):
+    r"""Return the metric evaluator for link prediction task. The supported metrics includes: ``accuracy``, ``f1_score``, ``confusion_matrix``, ``auc``.
+    
+    Args:
+        ``metric_configs`` (``List[Union[str, Dict[str, dict]]]``): The metric configurations. The key is the metric name and the value is the metric parameters.
+        ``validate_index`` (``int``): The specified metric index used for validation. Defaults to ``0``.
+    """
+
+    def __init__(
+        self,
+        metric_configs: List[Union[str, Dict[str, dict]]],
+        validate_index: int = 0,
+    ):
+        super().__init__("link_prediction", metric_configs, validate_index)
+
+    def validate(self, y_true: torch.LongTensor, y_pred: torch.Tensor):
+        r"""Return the result of the evaluation on the specified ``validate_index``-th metric.
+
+        Args:
+            ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+            ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+        """
+        return super().validate(y_true, y_pred)
+
+    def test(self, y_true: torch.LongTensor, y_pred: torch.Tensor):
+        r"""Return results of the evaluation on all the metrics in ``metric_configs``.
+
+        Args:
+            ``y_true`` (``torch.LongTensor``): The ground truth labels. Size :math:`(N_{samples}, )`.
+            ``y_pred`` (``torch.Tensor``): The predicted labels. Size :math:`(N_{samples}, N_{class})` or :math:`(N_{samples}, )`.
+        """
+        return super().test(y_true, y_pred)

--- a/dhg/metrics/link_prediction.py
+++ b/dhg/metrics/link_prediction.py
@@ -65,8 +65,9 @@ def accuracy(y_true: torch.LongTensor, y_pred: torch.Tensor):
         >>> dm.link_prediction.accuracy(y_true, y_pred)
         0.3333333432674408
     """
+    y_pred = torch.where(y_pred >= y_pred.mean(), 1, 0)
     y_true, y_pred = _format_inputs(y_true, y_pred)
-    return (y_true == y_pred).float().mean().item()
+    return sm.accuracy_score(y_true, y_pred)
 
 
 def f1_score(y_true: torch.LongTensor, y_pred: torch.Tensor, average: str = "macro"):
@@ -94,6 +95,7 @@ def f1_score(y_true: torch.LongTensor, y_pred: torch.Tensor, average: str = "mac
         >>> dm.link_prediction.f1_score(y_true, y_pred, "weighted")
         0.41666666666666663
     """
+    y_pred = torch.where(y_pred >= y_pred.mean(), 1, 0)
     y_true, y_pred = _format_inputs(y_true, y_pred)
     return sm.f1_score(y_true, y_pred, average=average)
 

--- a/tests/metrics/test_link_prediction.py
+++ b/tests/metrics/test_link_prediction.py
@@ -1,0 +1,26 @@
+import pytest
+
+import torch
+import numpy as np
+from sklearn.metrics import f1_score, confusion_matrix
+import dhg.metrics.link_prediction as dm
+
+
+def test_accuracy():
+    y_true = torch.tensor([0, 1, 2, 0, 1, 3])
+    y_pred = torch.tensor([0, 2, 1, 0, 2, 3])
+    assert dm.accuracy(y_true, y_pred) == 0.5
+
+
+def test_f1_score():
+    y_true = torch.tensor([0, 1, 2, 0, 1, 3])
+    y_pred = torch.tensor([0, 2, 1, 0, 2, 3])
+    assert dm.f1_score(y_true, y_pred, 'macro') == f1_score(y_true, y_pred, average='macro')
+    assert dm.f1_score(y_true, y_pred, 'micro') == f1_score(y_true, y_pred, average='micro')
+    assert dm.f1_score(y_true, y_pred, 'weighted') == f1_score(y_true, y_pred, average='weighted')
+
+
+def test_confusion_matrix():
+    y_true = torch.tensor([0, 1, 2, 0, 1, 3])
+    y_pred = torch.tensor([0, 2, 1, 0, 2, 3])
+    assert np.all(dm.confusion_matrix(y_true, y_pred) == confusion_matrix(y_true, y_pred))


### PR DESCRIPTION
Link prediction也是分类任务，模仿节点分类任务的metric添加accuracy，f1_score，confusion_matrix，auc。其中accuracy和 F1 分数的截止阈值选择所有测试超链接分数的平均值，这一点是参考论文 [A Survey on Hyperlink Prediction](http://arxiv.org/abs/2207.02911) 中提到的：
> We ﬁrst considered a negative sampling strategy with α = 0.5 and β = 1 as used in NHP. For each network, we randomly split the hyperlink set including positive and negative hyperlinks into training and testing sets by a ratio of 3:2 over 10 trials (no negative sample was introduced in the training set for HPRA and C3MM). We trained the six learning models on the training set and tested on the testing set. The results are shown in Table IV, where each value is the mean over 10 trials, and we picked the mean of all the testing hyperlink scores as the cutoff threshold for computing the F1 score.